### PR TITLE
Fix helper name

### DIFF
--- a/src/app/private/(tabs)/balances/index.tsx
+++ b/src/app/private/(tabs)/balances/index.tsx
@@ -8,14 +8,14 @@ import { ScreenStateEnum } from '@/enums/screenStates';
 //import { useDatabase } from '@/hooks/useDatabase';
 import { useBoundStore } from '@/store';
 import { theme } from '@/styles/theme';
-import { getLastAndFoward5Years } from '@/utils';
+import { getLastAndForward5Years } from '@/utils';
 import { useFocusEffect } from 'expo-router';
 import LottieView from 'lottie-react-native';
 import { Calendar, Filter } from 'lucide-react-native';
 import { useCallback, useEffect } from 'react';
 import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
 
-const years = getLastAndFoward5Years();
+const years = getLastAndForward5Years();
 
 const formatDate = (date: string): string => {
   const [ano, mes] = (date || '').split('-');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,7 +41,7 @@ export function getAllMonthsOfYear() {
   return months;
 }
 
-export function getLastAndFoward5Years() {
+export function getLastAndForward5Years() {
   const currentYear = new Date().getFullYear() + 5;
   const years = [];
 


### PR DESCRIPTION
## Summary
- fix mis-typed helper name `getLastAndForward5Years`
- update uses in Balances page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68459dddcc9c83219116b164e30ba86a